### PR TITLE
Admin auth

### DIFF
--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -180,7 +180,7 @@ function RegisterUser($details) {
 function GetCustomerCount() {
     global $Customer;
     $count = $Customer->getCustomerCount();
-    if ($count) return $count;
+    if (!is_null($count)) return $count;
     else return false;
 }
 
@@ -414,7 +414,7 @@ function GetAllProducts() {
 function GetProductCount() {
     global $Product;
     $count = $Product->getProductCount();
-    if ($count) return $count;
+    if (!is_null($count)) return $count;
     else return false;
 }
 

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -1084,7 +1084,10 @@ function VerfiyToken($token) {
             $newTk = GenerateToken($tk["AdminID"]);
             $success = $Admin->deleteToken($tk["Token"]);
 
-            if ($success && (!empty($newTk))) return true;
+            if ($success && (!empty($newTk)))  {
+                $_SESSION["adminToken"] = $newTk;
+                return true;
+            }
             else return false;
         }
         else return false;
@@ -1096,9 +1099,10 @@ function VerfiyToken($token) {
  * Create a token
  * @param int $adminID The admin to associate to (defaults to $_SESSION["adminID"])
  * @param DateTime $expiry The expiry time for the token (defaults to now+20mins)
+ * @param string $name The name for token access type
  * @return string The token, or an empty string if failed
  */
-function GenerateToken($adminID = null, $expiry=null) {
+function GenerateToken($adminID = null, $expiry=null, $name="ADMIN_DASHBOARD_ACCESS") {
     global $Admin;
     //assign current admin as adminID if not supplied
     if (is_null($adminID)) {
@@ -1132,8 +1136,9 @@ function GenerateToken($adminID = null, $expiry=null) {
             return "";
         }
     }
+    if (!(CheckExists($name)) || !(gettype($name) == "string")) return "";
 
-    $tk = $Admin->createToken($adminID, $expiry);
+    $tk = $Admin->createToken($adminID, $expiry, $name);
     if (is_null($tk)) return "";
     else return $tk["Token"];
 }

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -1061,17 +1061,6 @@ function GetPreviousOrders() {
 //
 //  --------------------------------------------------
 
-/*
-    List to add:
-        Stock all
-        Add product
-        Delete product - don't delete, just set stock to -1 to archive it
-        Add image
-        Remove image
-        Make MainImage
-        Update customer
-*/
-
 /**
  * Add an admin to the database
  * 
@@ -1290,8 +1279,6 @@ function CheckAdminLoggedIn() {
  * @return string Empty if success, otherwise an err message
  */
 function UpdateProductDetail($productID, $field, $value) {
-    //if (!CheckAdminLoggedIn()) return "Not logged in";
-
     global $Product;
     escapeHTML($productID, $field, $value);
     $fields = array("Name", "Price", "Stock", "Description", "CategoryID");
@@ -1377,8 +1364,6 @@ function UpdateProductDetail($productID, $field, $value) {
  * @return string empty if success, otherwise false
  */
 function AddProduct($details) {
-    //if (!CheckAdminLoggedIn()) return "Not logged in";
-
     global $Product;
     escapeHTML($details);
     if (!(gettype($details) == "array")) return "Invalid details";
@@ -1461,7 +1446,6 @@ function AddProduct($details) {
 function DeleteProduct($productID) {
     global $Product;
     escapeHTML($productID);
-    // if (!CheckAdminLoggedIn()) return "Not logged in";
     try {
         $productID = (int)$productID;
     } catch (Exception $e) {
@@ -1502,8 +1486,6 @@ function DeleteProduct($productID) {
  * @return string Empty if success, otherwise false
  */
 function UpdateCustomerInfo($customerID, $field, $value) {
-    //if (!CheckAdminLoggedIn()) return "Not logged in";
-    
     global $Customer;
     escapeHTML($customerID, $field, $value);
     $fields = array('Username', 'Email', 'CustomerAddress', 'PasswordHash');
@@ -1552,7 +1534,6 @@ function UpdateCustomerInfo($customerID, $field, $value) {
 function AddProductImage($productID, $fileName, $mainImage) {
     global $Product;
     escapeHTML($productID, $fileName, $mainImage);
-    //if (!CheckAdminLoggedIn()) return "Not logged in";
     try {
         $productID = (int)$productID;
     } catch (Exception $e) {
@@ -1582,7 +1563,6 @@ function AddProductImage($productID, $fileName, $mainImage) {
 function UpdateProductImage($productID, $fileName, $mainImage) {
     global $Product;
     escapeHTML($productID, $fileName, $mainImage);
-    //if (!CheckAdminLoggedIn()) return "Not logged in";
     try {
         $productID = (int)$productID;
     } catch (Exception $e) {

--- a/index.php
+++ b/index.php
@@ -118,47 +118,47 @@ switch ($requestPath) {
         break;
 
     case '/api/updateOrderStatus':
-        require __DIR__ . '/api/updateOrderStatus.php';
+        handleAPIRequest('updateOrderStatus');
         break;
 
     case '/api/getProduct':
-        require __DIR__ . '/api/getProduct.php';
+        handleAPIRequest('getProduct.php');
         break;
 
     case '/api/addProduct':
-        require __DIR__ . '/api/addProduct.php';
+        handleAPIRequest('addProduct.php');
         break;
 
     case '/api/editProduct':
-        require __DIR__ . '/api/editProduct.php';
+        handleAPIRequest('editProduct.php');
         break;
     
     case '/api/deleteProduct':
-        require __DIR__ . '/api/deleteProduct.php';
+        handleAPIRequest('deleteProduct.php');
         break;
     
     case '/api/getCustomer':
-        require __DIR__ . '/api/getCustomer.php';
+        handleAPIRequest('getCustomer.php');
         break;
     
     case '/api/editCustomer':
-        require __DIR__ . '/api/editCustomer.php';
+        handleAPIRequest('editCustomer.php');
         break;
 
     case '/api/deleteCustomer':
-        require __DIR__ . '/api/deleteCustomer.php';
+        handleAPIRequest('deleteCustomer.php');
         break;
 
     case '/api/getAdmin':
-        require __DIR__ . '/api/getAdmin.php';
+        handleAPIRequest('getAdmin.php');
         break;
 
     case '/api/editAdmin':
-        require __DIR__ . '/api/editAdmin.php';
+        handleAPIRequest('editAdmin.php');
         break;
 
     case '/api/addAdmin':
-        require __DIR__ . '/api/addAdmin.php';
+        handleAPIRequest('addAdmin.php');
         break;
 
     default:
@@ -503,8 +503,14 @@ function handleChangePasswordRequest(){
  * Handles requests to view the dashboard
  */
 function handleDashboardRequest() {
+    PruneTokens();
     if (CheckAdminLoggedIn()) {
-        require __DIR__ . '/view/admin/dashboard.php';
+        if (VerfiyToken($_SESSION["adminToken"])) {
+            require __DIR__ . '/view/admin/dashboard.php';
+        } 
+        else {
+            handle404Request();
+        }
     } 
     else { 
         header("Location:/adminLogin"); //redirect to login page
@@ -536,6 +542,71 @@ function handleAdminLogout() {
     unset($_SESSION);
     session_destroy();
     header("Location:/admin");
+}
+
+/**
+ * Handles API requests
+ * 
+ * @param string $path Path to request
+ */
+function handleAPIRequest($path) {
+    PruneTokens();
+    if (!CheckExists($_POST["Token"])) {
+        $result = VerfiyToken($_SESSION["adminToken"]);
+        if (!$result) http_response_code(403);
+    }
+    else {
+        $result = VerfiyToken($_POST["Token"]);
+        if (!$result) http_response_code(403);
+    }
+
+    switch ($path) {
+        case 'updateOrderStatus':
+            require __DIR__ . '/api/updateOrderStatus.php';
+            break;
+        case 'getProduct':
+            require __DIR__ . '/api/getProduct.php';
+            break;
+        
+        case 'addProduct':
+            require __DIR__ . '/api/addProduct.php';
+            break;
+        
+        case 'editProduct':
+            require __DIR__ . '/api/editProduct.php';
+            break;
+            
+        case 'deleteProduct':
+            require __DIR__ . '/api/deleteProduct.php';
+            break;
+            
+        case 'getCustomer':
+            require __DIR__ . '/api/getCustomer.php';
+            break;
+            
+        case 'editCustomer':
+            require __DIR__ . '/api/editCustomer.php';
+            break;
+        
+        case 'deleteCustomer':
+            require __DIR__ . '/api/deleteCustomer.php';
+            break;
+        
+        case 'getAdmin':
+            require __DIR__ . '/api/getAdmin.php';
+            break;
+        
+        case 'editAdmin':
+            require __DIR__ . '/api/editAdmin.php';
+            break;
+        
+        case 'addAdmin':
+            require __DIR__ . '/api/addAdmin.php';
+            break;
+        default:
+            handle404Request();
+            break;
+    }
 }
 
 

--- a/index.php
+++ b/index.php
@@ -106,7 +106,15 @@ switch ($requestPath) {
         break;
     
     case '/admin':
-        require __DIR__ . '/view/admin/dashboard.php';
+        handleDashboardRequest();
+        break;
+
+    case '/adminLogin':
+        handleAdminLogin();
+        break;
+    
+    case '/adminLogout':
+        handleAdminLogout();
         break;
 
     case '/api/updateOrderStatus':
@@ -489,6 +497,45 @@ function handleChangePasswordRequest(){
     }
 
 
+}
+
+/**
+ * Handles requests to view the dashboard
+ */
+function handleDashboardRequest() {
+    if (CheckAdminLoggedIn()) {
+        require __DIR__ . '/view/admin/dashboard.php';
+    } 
+    else { 
+        header("Location:/adminLogin"); //redirect to login page
+    }
+}
+
+/**
+ * Handles admin logins
+ */
+function handleAdminLogin() {
+    if (!isset($_POST["username"])) {
+        require __DIR__ . '/view/AdminLogin.php';
+    }
+    else {
+        if (!isset($_POST["password"])) header("Location:/adminLogin");
+        else {
+            $result = AttemptAdminLogin($_POST["username"], $_POST["password"]);
+            if (empty($result)) header("Location:/admin");
+            //TODO show error message on adminLogin page
+            else header("Location:/adminLogin");
+        }
+    }
+}
+
+/**
+ * Handles admin logouts
+ */
+function handleAdminLogout() {
+    unset($_SESSION);
+    session_destroy();
+    header("Location:/admin");
 }
 
 

--- a/model/Admin.php
+++ b/model/Admin.php
@@ -127,7 +127,7 @@ class AdminModel {
      * @param DateTime $expiry the expiry time of the token
      * @return array|null The created token, or null if failed.
      */
-    public function createToken($adminID, $expiry) {
+    public function createToken($adminID, $expiry, $name) {
         //format DateTime to string
         $exp = $expiry->format("Y-m-d H:i:s");
         //generate a token
@@ -147,16 +147,19 @@ class AdminModel {
         $insertQuery = "INSERT INTO `APITokens` (
                         `AdminID`,
                         `Token`,
-                        `ExpiresAt`
+                        `ExpiresAt`,
+                        `TokenName`
                     ) VALUES (
                         :adminID,
                         :token,
-                        :expiry
+                        :expiry,
+                        :TokenName
                     )";
         $insertStatement = $this->database->prepare($insertQuery);
         $insertStatement->bindParam(':adminID', $adminID, PDO::PARAM_INT);
         $insertStatement->bindParam(':token', $token, PDO::PARAM_STR);
         $insertStatement->bindParam(':expiry', $exp, PDO::PARAM_STR);
+        $insertStatement->bindParam(':TokenName', $name, PDO::PARAM_STR);
 
         return $insertStatement->execute() ? $this->getTokenByID($token) : null;
     }

--- a/model/Admin.php
+++ b/model/Admin.php
@@ -224,7 +224,7 @@ class AdminModel {
      * @return boolean True if success, otherwise false
      */
     public function deleteToken($token) {
-        $query = "DELETE * FROM `APITokens` WHERE `Token` = :token";
+        $query = "DELETE FROM `APITokens` WHERE `Token` = :token";
         $statement = $this->database->prepare($query);
         $statement->bindParam(':token', $token, PDO::PARAM_STR);
 

--- a/model/Admin.php
+++ b/model/Admin.php
@@ -119,6 +119,117 @@ class AdminModel {
             return null; // Failed to execute query
         }
     }
+
+    /**
+     * Creates an API token for a specified admin
+     * 
+     * @param int $adminID the adminID
+     * @param DateTime $expiry the expiry time of the token
+     * @return array|null The created token, or null if failed.
+     */
+    public function createToken($adminID, $expiry) {
+        //format DateTime to string
+        $exp = $expiry->format("Y-m-d H:i:s");
+        //generate a token
+        $token = "";
+        $hex = "0123456789abcdef";
+        $h = str_split($hex);
+        do {
+            $token = "";
+            for ($i = 0; $i < 16; $i++) {
+                $token = $token . $h[random_int(0, count($h)-1)];
+            }
+        // this is meant to stop collisions but also
+        // scary while loop :(
+        } while (!is_null($this->getTokenByID($token)));
+
+
+        $insertQuery = "INSERT INTO `APITokens` (
+                        `AdminID`,
+                        `Token`,
+                        `ExpiresAt`
+                    ) VALUES (
+                        :adminID,
+                        :token,
+                        :expiry
+                    )";
+        $insertStatement = $this->database->prepare($insertQuery);
+        $insertStatement->bindParam(':adminID', $adminID, PDO::PARAM_INT);
+        $insertStatement->bindParam(':token', $token, PDO::PARAM_STR);
+        $insertStatement->bindParam(':expiry', $exp, PDO::PARAM_STR);
+
+        return $insertStatement->execute() ? $this->getTokenByID($token) : null;
+    }
+
+    /**
+     * Gets API token by supplied ID
+     * 
+     * @param string $token The token
+     * @return array|null The token w/ info or null if not found.
+     */
+    public function getTokenByID($token) {
+        $query = "SELECT * FROM `APITokens` WHERE `Token` = :token";
+        $statement = $this->database->prepare($query);
+        $statement->bindParam(':token', $token, PDO::PARAM_STR);
+
+        if ($statement->execute()) {
+            $tk = $statement->fetch(PDO::FETCH_ASSOC);
+            return $tk ? $tk : null;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Gets API token associated with admin
+     * 
+     * @param int $adminID the AdminID for the token
+     * @return array|null The tokens associated with the admin, or null if not found.
+     */
+    public function getTokensByAdmin($adminID)  {
+        $query = "SELECT * FROM `APITokens` WHERE `AdminID` = :adminID";
+        $statement = $this->database->prepare($query);
+        $statement->bindParam(':adminID', $adminID, PDO::PARAM_INT);
+
+        if ($statement->execute()) {
+            $tk = $statement->fetchAll(PDO::FETCH_ASSOC);
+            return $tk ? $tk : null;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Gets all API tokens
+     * 
+     * @return array|null Array of tokens, or null if failed
+     */
+    public function getAllTokens() {
+        $query = "SELECT * FROM `APITokens`";
+        $statement = $this->database->prepare($query);
+
+        if ($statement->execute()) {
+            $tk = $statement->fetchAll(PDO::FETCH_ASSOC);
+            return $tk ? $tk : null;
+        } else {
+            return null;
+        }
+    }
+
+
+    /**
+     * Deletes an API token
+     * 
+     * @param string $token the Token to delete
+     * @return boolean True if success, otherwise false
+     */
+    public function deleteToken($token) {
+        $query = "DELETE * FROM `APITokens` WHERE `Token` = :token";
+        $statement = $this->database->prepare($query);
+        $statement->bindParam(':token', $token, PDO::PARAM_STR);
+
+        return $statement->execute();
+    }
 }
 
 class Admin {

--- a/model/Customer.php
+++ b/model/Customer.php
@@ -133,14 +133,17 @@ class CustomerModel {
     /**
      * Count the number of customers in the database.
      * 
-     * @return int The number of customers in the database.
+     * @return int|null The number of customers in the database, or null if failed.
      */
     
     public function getCustomerCount() {
         $query = "SELECT COUNT(*) FROM `Customers`";
         $statement = $this->database->prepare($query);
-        $statement->execute();
-        return $statement->fetchColumn();
+        if ($statement->execute()) {
+            return $statement->fetchColumn();
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/model/Orders.php
+++ b/model/Orders.php
@@ -347,7 +347,7 @@ class OrdersModel {
             $orderCount = $statement->fetch(PDO::FETCH_ASSOC);
             return $orderCount ? $orderCount['COUNT(*)'] : 0;
         } else {
-            return 0; // Failed to execute query
+            return null; // Failed to execute query
         }
     }
 }

--- a/model/Products.php
+++ b/model/Products.php
@@ -370,13 +370,16 @@ class ProductModel {
     /**
      * Count the number of total products in the database.
      * 
-     * @return int The number of products in the database.
+     * @return int|null The number of products in the database, or null if failed.
      */
     public function getProductCount() {
         $query = "SELECT COUNT(*) FROM `Products`";
         $statement = $this->database->prepare($query);
-        $statement->execute();
-        return $statement->fetchColumn();
+        if ($statement->execute()) {
+            return $statement->fetchColumn();
+        } else {
+            return null;
+        }
     }
     
 }

--- a/setup/evotechDB.sql
+++ b/setup/evotechDB.sql
@@ -248,6 +248,7 @@ CREATE TABLE if not exists `APITokens` (
   `Token` VARCHAR(16) NOT NULL,
   `ExpiresAt` TIMESTAMP NULL DEFAULT NULL,
   `TokenName` VARCHAR(200) NOT NULL,
+  `CreatedAt` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`Token`),
   FOREIGN KEY (`AdminID`) REFERENCES `AdminCredentials` (`AdminID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;

--- a/setup/evotechDB.sql
+++ b/setup/evotechDB.sql
@@ -247,6 +247,7 @@ CREATE TABLE if not exists `APITokens` (
   `AdminID` INT NOT NULL,
   `Token` VARCHAR(16) NOT NULL,
   `ExpiresAt` TIMESTAMP NULL DEFAULT NULL,
+  `TokenName` VARCHAR(200) NOT NULL,
   PRIMARY KEY (`Token`),
   FOREIGN KEY (`AdminID`) REFERENCES `AdminCredentials` (`AdminID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;

--- a/setup/evotechDB.sql
+++ b/setup/evotechDB.sql
@@ -238,3 +238,15 @@ CREATE TABLE if not exists `ProductReviews` (
   FOREIGN KEY (`CustomerID`) REFERENCES `Customers` (`CustomerID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
+-- --------------------------------------------------------
+-- Table for API Tokens
+-- The `Token` is the unique identifier for each token,
+-- The `ExpiresAt` field is the timestamp for when it will expire
+-- --------------------------------------------------------
+CREATE TABLE if not exists `APITokens` (
+  `AdminID` INT NOT NULL,
+  `Token` VARCHAR(16) NOT NULL,
+  `ExpiresAt` TIMESTAMP NULL DEFAULT NULL,
+  PRIMARY KEY (`Token`),
+  FOREIGN KEY (`AdminID`) REFERENCES `AdminCredentials` (`AdminID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;

--- a/view/AdminLogin.php
+++ b/view/AdminLogin.php
@@ -25,7 +25,7 @@
 
           
 
-            <form action="login" method="POST">
+            <form action="adminLogin" method="POST">
                 <p><b>Admin's username:</b></p>
                 <input type="text" name="username" placeholder="Enter username:" required/>
                 <br>

--- a/view/admin/dashboard.php
+++ b/view/admin/dashboard.php
@@ -56,7 +56,7 @@
     <div class="w-100"></div>
     <div class="navbar-nav">
       <div class="nav-item text-nowrap">
-        <a class="nav-link px-3" href="#">Sign out</a>
+        <a class="nav-link px-3" href="/adminLogout">Sign out</a>
       </div>
     </div>
   </header>


### PR DESCRIPTION
Changes: 

- Fixed getCount methods to account for edge case where there were no items (which would report at database failure instead of 0 items)
- Escaped all input with htmlspecialchars
- Implemented Admin login/logout
- (Mostly) Implemented API tokens

To use these changes the following table needs to be added:
```
CREATE TABLE if not exists `APITokens` (
  `AdminID` INT NOT NULL,
  `Token` VARCHAR(16) NOT NULL,
  `ExpiresAt` TIMESTAMP NULL DEFAULT NULL,
  PRIMARY KEY (`Token`),
  FOREIGN KEY (`AdminID`) REFERENCES `AdminCredentials` (`AdminID`)
)
```